### PR TITLE
Update deep merge interface (api)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,9 @@
 # [5.0.0](https://github.com/TehShrike/deepmerge/releases/tag/v5.0.0)
 
+- Update to the internals exposed in the passed `options` object
+  - `deepMerge`
+  - `deepClone`
+  - Breaking: `cloneUnlessOtherwiseSpecified` has been removed - `deepClone` is very similar
 - Breaking: Cloning is not turned off by default
 - Breaking: Endpoint are now exported in esm style [#215](https://github.com/TehShrike/deepmerge/pull/215)
   - The main merge function is now a default export

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 # [5.0.0](https://github.com/TehShrike/deepmerge/releases/tag/v5.0.0)
 
+- Breaking: Cloning is not turned off by default
 - Breaking: Endpoint are now exported in esm style [#215](https://github.com/TehShrike/deepmerge/pull/215)
   - The main merge function is now a default export
   - The all merge function is now exported as "deepmergeAll" and is no longer a property on the main merge function.

--- a/readme.md
+++ b/readme.md
@@ -210,11 +210,7 @@ customMergeOutput.someProperty instanceof SuperSpecial // => false
 
 #### `customMerge`
 
-Specifies a function which can be used to override the default merge behavior for a property, based on the property name.
-
-The `customMerge` function will be passed the key for each property, and should return the function which should be used to merge the values for that property.
-
-It may also return undefined, in which case the default merge behaviour will be used.
+Specifies a function which can be used to override the default merge behavior.
 
 ```js
 const alex = {
@@ -236,10 +232,13 @@ const tony = {
 const mergeNames = (nameA, nameB) => `${nameA.first} and ${nameB.first}`
 
 const options = {
-  customMerge: (key) => {
+  customMerge: (x, y, key, options) => {
     if (key === 'name') {
-      return mergeNames
+      return mergeNames(x, y)
     }
+
+    // Use deafult merging.
+    return options.deepMerge(x, y)
   }
 }
 

--- a/readme.md
+++ b/readme.md
@@ -112,8 +112,8 @@ There are multiple ways to merge two arrays, below are a few examples but you ca
 
 Your `arrayMerge` function will be called with three arguments: a `target` array, the `source` array, and an `options` object with these properties:
 
-- `isMergeableObject(value)`
-- `cloneUnlessOtherwiseSpecified(value, options)`
+- `isMergeable(value)`
+- `deepClone(value, options)`
 
 ##### `arrayMerge` example: overwrite target array
 
@@ -141,7 +141,7 @@ const combineMerge = (target, source, options) => {
 
   source.forEach((item, index) => {
     if (typeof destination[index] === 'undefined') {
-      destination[index] = options.cloneUnlessOtherwiseSpecified(item, options)
+      destination[index] = options.clone ? options.deepClone(item) : item
     } else if (options.isMergeable(item)) {
       destination[index] = deepmerge(target[index], item, options)
     } else if (target.indexOf(item) === -1) {

--- a/readme.md
+++ b/readme.md
@@ -251,11 +251,9 @@ result.pets // => ['Cat', 'Parrot', 'Dog']
 
 #### `clone`
 
-*Deprecated.*
+Defaults to `false`.
 
-Defaults to `true`.
-
-If `clone` is `false` then child objects will be copied directly instead of being cloned.  This was the default behavior before version 2.x.
+If `clone` is `true` then child objects will be cloned into the destination object instead of being directly copied. This was the default behavior before version 5.x.
 
 ## Testing
 

--- a/src/options.ts
+++ b/src/options.ts
@@ -52,7 +52,7 @@ export type ObjectMerge<K = any> = (
 	key: K
 ) => ((target: any, source: any, options: FullOptions) => any) | undefined
 
-const defaultClone = true as const
+const defaultClone = false as const
 
 function defaultIsMergeable(value: unknown): value is Record<Property, unknown> | Array<unknown> {
 	return Array.isArray(value) || isPlainObj(value)

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,6 @@
 import isPlainObj from "is-plain-obj"
 
-import { getSubtree, getDeepCloneFn } from "./impl"
+import { getSubtree, getDeepCloneFn, getDeepMergeFn } from "./impl"
 import type { FlattenAlias, Property } from "./types"
 
 /**
@@ -33,6 +33,7 @@ export type FullOptions<O extends Options = Options> = FlattenAlias<{
 		? typeof defaultIsMergeable
 		: NonNullable<O[`isMergeable`]>
 	readonly deepClone: ReturnType<typeof getDeepCloneFn>
+	readonly deepMerge: ReturnType<typeof getDeepMergeFn>
 }>
 
 /**
@@ -53,9 +54,7 @@ export type Clone<T = any> = boolean | ((object: T, options: FullOptions) => any
 /**
  * A function that merges any 2 non-arrays values.
  */
-export type ObjectMerge<K = any> = (
-	key: K
-) => ((target: any, source: any, options: FullOptions) => any) | undefined
+export type ObjectMerge<K = any> = ((target: any, source: any, key: K, options: FullOptions) => any) | undefined
 
 const defaultClone = false as const
 
@@ -93,6 +92,7 @@ export function getFullOptions<O extends Options>(options?: O): FullOptions<O> {
 		...overrides,
 	} as any
 	fullOptions.deepClone = getDeepCloneFn(fullOptions)
+	fullOptions.deepMerge = getDeepMergeFn(fullOptions)
 
 	return fullOptions
 }

--- a/test/custom-array-merge.ts
+++ b/test/custom-array-merge.ts
@@ -42,8 +42,8 @@ test(`cloner function is available for merge functions to use`, (t) => {
 	let customMergeWasCalled = false
 	const cloneMerge: Options[`arrayMerge`] = (target, source, options) => {
 		customMergeWasCalled = true
-		t.ok(options.cloneUnlessOtherwiseSpecified, `cloner function is available`)
-		return target.concat(source).map((element) => options.cloneUnlessOtherwiseSpecified(element, options))
+		t.ok(options.deepClone, `cloner function is available`)
+		return target.concat(source).map((element) => options.deepClone(element))
 	}
 
 	const src = {

--- a/test/custom-cloning.ts
+++ b/test/custom-cloning.ts
@@ -1,0 +1,52 @@
+import type { Options } from "deepmerge"
+import deepmerge from "deepmerge"
+import test from "tape"
+
+test(`custom clone is called`, (t) => {
+	let cloneFunctionCallCount = 0
+	const overwriteClone: Options[`clone`] = (value, options) => {
+		cloneFunctionCallCount++
+		t.equal(options.clone, overwriteClone)
+
+		return value
+	}
+
+	const source = {
+		someArray: [ 1, 2 ],
+		someObject: { what: `yes` },
+	}
+
+	const actual = deepmerge({}, source, { clone: overwriteClone })
+	const expected = {
+		someArray: source.someArray,
+		someObject: source.someObject,
+	}
+
+	t.equal(cloneFunctionCallCount, 2)
+	t.deepEqual(actual, expected)
+	t.equal(actual.someArray, expected.someArray)
+	t.equal(actual.someObject, expected.someObject)
+
+	t.end()
+})
+
+test(`custom clone can replicate default clone`, (t) => {
+	const overwriteClone: Options[`clone`] = (value, options) => options.deepClone(value)
+
+	const source = {
+		someArray: [ 1, 2 ],
+		someObject: { what: `yes` },
+	}
+
+	const actual = deepmerge({}, source, { clone: overwriteClone })
+	const expected = {
+		someArray: source.someArray,
+		someObject: source.someObject,
+	}
+
+	t.deepEqual(actual, expected)
+	t.notEqual(actual.someArray, expected.someArray)
+	t.notEqual(actual.someObject, expected.someObject)
+
+	t.end()
+})

--- a/test/merge-all.ts
+++ b/test/merge-all.ts
@@ -61,31 +61,31 @@ test(`invoke merge on every item in array with clone should clone all elements`,
 	t.end()
 })
 
-test(`invoke merge on every item in array clone=false should not clone all elements`, (t) => {
+test(`invoke merge on every item in array clone=true should clone all elements`, (t) => {
 	const firstObject = { a: { d: 123 } }
 	const secondObject = { b: { e: true } }
 	const thirdObject = { c: { f: `string` } }
 
-	const mergedWithoutClone = deepmergeAll([ firstObject, secondObject, thirdObject ], { clone: false })
+	const mergedWithoutClone = deepmergeAll([ firstObject, secondObject, thirdObject ], { clone: true })
 
-	t.equal(mergedWithoutClone.a, firstObject.a)
-	t.equal(mergedWithoutClone.b, secondObject.b)
-	t.equal(mergedWithoutClone.c, thirdObject.c)
+	t.notEqual(mergedWithoutClone.a, firstObject.a)
+	t.notEqual(mergedWithoutClone.b, secondObject.b)
+	t.notEqual(mergedWithoutClone.c, thirdObject.c)
 
 	t.end()
 })
 
 
-test(`invoke merge on every item in array without clone should clone all elements`, (t) => {
+test(`invoke merge on every item in array without clone should not clone all elements`, (t) => {
 	const firstObject = { a: { d: 123 } }
 	const secondObject = { b: { e: true } }
 	const thirdObject = { c: { f: `string` } }
 
 	const mergedWithoutClone = deepmergeAll([ firstObject, secondObject, thirdObject ])
 
-	t.notEqual(mergedWithoutClone.a, firstObject.a)
-	t.notEqual(mergedWithoutClone.b, secondObject.b)
-	t.notEqual(mergedWithoutClone.c, thirdObject.c)
+	t.equal(mergedWithoutClone.a, firstObject.a)
+	t.equal(mergedWithoutClone.b, secondObject.b)
+	t.equal(mergedWithoutClone.c, thirdObject.c)
 
 	t.end()
 })

--- a/test/merge-plain-objects.ts
+++ b/test/merge-plain-objects.ts
@@ -1,12 +1,12 @@
 import deepmerge from "deepmerge"
 import test from "tape"
 
-test(`plain objects are merged by default`, (t) => {
+test(`plain objects are merged by default and can be cloned`, (t) => {
 	const input = {
 		newObject: new Object(),
 		objectLiteral: { a: 123 },
 	}
-	const output = deepmerge({}, input)
+	const output = deepmerge({}, input, { clone: true })
 
 	t.deepEqual(output.newObject, input.newObject)
 	t.notEqual(output.newObject, input.newObject)
@@ -16,13 +16,13 @@ test(`plain objects are merged by default`, (t) => {
 	t.end()
 })
 
-test(`instantiated objects are copied by reference`, (t) => {
+test(`instantiated objects are copied by reference with clone=true`, (t) => {
 	const input = {
 		date: new Date(),
 		error: new Error(),
 		regex: /regex/,
 	}
-	const output = deepmerge({}, input)
+	const output = deepmerge({}, input, { clone: true })
 
 	t.equal(output.date, input.date)
 	t.equal(output.error, input.error)

--- a/test/merge.ts
+++ b/test/merge.ts
@@ -507,12 +507,12 @@ test(`should handle custom merge functions`, (t) => {
 	}
 
 	const options: Options = {
-		customMerge: (key) => {
+		customMerge: (x, y, key, options) => {
 			if (key === `people`) {
-				return mergePeople
+				return mergePeople(x, y)
 			}
 
-			return deepmerge
+			return options.deepMerge(x, y)
 		},
 	}
 
@@ -551,52 +551,18 @@ test(`should handle custom merge functions`, (t) => {
 
 	const mergeLetters = () => `merged letters`
 
-	const options = {
-		customMerge: (key: string) => {
+	const options: Options = {
+		customMerge: (x, y, key: string, options) => {
 			if (key === `letters`) {
-				return mergeLetters
+				return mergeLetters()
 			}
+
+			return options.deepMerge(x, y)
 		},
 	}
 
 	const expected = {
 		letters: `merged letters`,
-		people: {
-			first: `Smith`,
-			second: `Bertson`,
-			third: `Car`,
-		},
-	}
-
-	const actual = deepmerge(target, source, options)
-	t.deepEqual(actual, expected)
-	t.end()
-})
-
-test(`should merge correctly if custom merge is not a valid function`, (t) => {
-	const target = {
-		letters: [ `a`, `b` ],
-		people: {
-			first: `Alex`,
-			second: `Bert`,
-		},
-	}
-
-	const source = {
-		letters: [ `c` ],
-		people: {
-			first: `Smith`,
-			second: `Bertson`,
-			third: `Car`,
-		},
-	}
-
-	const options: Options = {
-		customMerge: () => undefined,
-	}
-
-	const expected = {
-		letters: [ `a`, `b`, `c` ],
 		people: {
 			first: `Smith`,
 			second: `Bertson`,
@@ -659,10 +625,8 @@ test(`Falsey properties should be mergeable`, (t) => {
 			return true
 		},
 		customMerge() {
-			return function() {
-				customMergeWasCalled = true
-				return uniqueValue
-			}
+			customMergeWasCalled = true
+			return uniqueValue
 		},
 	})
 

--- a/test/merge.ts
+++ b/test/merge.ts
@@ -139,7 +139,7 @@ test(`should clone source and target`, (t) => {
 	t.end()
 })
 
-test(`should clone source and target`, (t) => {
+test(`should not clone source and target if not told to`, (t) => {
 	const src = {
 		b: {
 			c: `foo`,
@@ -153,8 +153,8 @@ test(`should clone source and target`, (t) => {
 	}
 
 	const merged = deepmerge(target, src)
-	t.notEqual(merged.a, target.a)
-	t.notEqual(merged.b, src.b)
+	t.equal(merged.a, target.a)
+	t.equal(merged.b, src.b)
 
 	t.end()
 })

--- a/test/prototype-poisoning.ts
+++ b/test/prototype-poisoning.ts
@@ -41,13 +41,11 @@ test(`merging objects with plain and non-plain properties`, (t) => {
 test(`merging strings works with a custom string merge`, (t) => {
 	const target = { name: `Alexander` }
 	const source = { name: `Hamilton` }
-	const customMerge: Options[`customMerge`] = (key) => {
+	const customMerge: Options[`customMerge`] = (target, source, key, options) => {
 		if (key === `name`) {
-			return function(target: string, source: string, options) {
-				return `${ target[0] }. ${ source.substring(0, 3) }`
-			}
+			return `${ (target as string)[0] }. ${ (source as string).substring(0, 3) }`
 		} else {
-			return deepmerge
+			return options.deepMerge(target, source)
 		}
 	}
 


### PR DESCRIPTION
### Changes

- Cloning is now off by default
- A custom clone function can now be provided
  - This is to help with the case of how to clone non-plain objects
- Updated the exposed internals
  - add `deepClone(value)`
    - deep clones a value in the same way that `cloneUnlessOtherwiseSpecified` did except an options object isn't supplied, the same original one is used.
  - add `deepMerge(x, y)`
     - deep merges two values in the same way that top level `deepmerge` does except an options object isn't supplied, the same original one is used.
  - remove `cloneUnlessOtherwiseSpecified(value)`
    - function no longer exists - replaced by `getSubtree` (not exposed) and `deepClone` (exposed)